### PR TITLE
Add option to list available stable versions and URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ _testmain.go
 *.prof
 bin
 pkg
-src/*
-gobu
-gobu-*
+src/gobu/src/*
+src/gobu/gobu
+src/gobu/gobu-*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ and architecture, sets GOROOT, GOPATH and runs default shell or your command.
 Usage of gobu:
   -GOPATH string
     	Overide GOPATH (default "/home/username/gobu")
+  -available
+      List available stable versions
   -env_path string
     	Location of GO instalation (default "/home/username/.gobu")
   -exec string

--- a/src/gobu/main.go
+++ b/src/gobu/main.go
@@ -118,7 +118,7 @@ func main() {
 	onlinePath = fmt.Sprintf(onlinePath, globalVersion, runtime.GOOS, arch)
 
 	if available {
-		versions := availableVersions()
+		versions := availableVersions(goDownloadPage())
 		for _, version := range versions {
 			fmt.Println(version[2:])
 		}

--- a/src/gobu/main.go
+++ b/src/gobu/main.go
@@ -15,6 +15,7 @@ import (
 var goPath = ""
 var execCmd = ""
 var envPath = ".gobu"
+var available = false
 var globalVersion = "1.7"
 var onlinePath = "https://storage.googleapis.com/golang/go%s.%s-%s.tar.gz"
 
@@ -41,6 +42,7 @@ func init() {
 	flag.StringVar(&globalVersion, "version", globalVersion, "Version of Golang you wish to use")
 	flag.StringVar(&goPath, "GOPATH", goPath, "Overide GOPATH")
 	flag.StringVar(&execCmd, "exec", "", "Run command instead of default shell")
+	flag.BoolVar(&available, "available", false, "List available stable versions")
 }
 
 func createStore(version string) {
@@ -114,6 +116,14 @@ func main() {
 		arch = "armv6l"
 	}
 	onlinePath = fmt.Sprintf(onlinePath, globalVersion, runtime.GOOS, arch)
+
+	if available {
+		versions := availableVersions()
+		for _, version := range versions {
+			fmt.Println(version[2:])
+		}
+		return
+	}
 
 	createStore(globalVersion)
 	download(globalVersion)

--- a/src/gobu/remote.go
+++ b/src/gobu/remote.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 func download(version string) {
@@ -37,7 +38,7 @@ func download(version string) {
 }
 
 func availableVersions() []string {
-	client := &http.Client{}
+	client := &http.Client{Timeout: time.Duration(5 * time.Second)}
 	req, err := http.NewRequest("GET", "https://golang.org/dl/", nil)
 
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")

--- a/src/gobu/remote.go
+++ b/src/gobu/remote.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 func download(version string) {
@@ -30,4 +34,66 @@ func download(version string) {
 	} else {
 		log.Printf("Skipping download")
 	}
+}
+
+func availableVersions() []string {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://golang.org/dl/", nil)
+
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Gobu; +https://github.com/dz0ny/gobu)")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	var line string
+	var parts []string
+	var versions []string
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	for scanner.Scan() {
+		line = scanner.Text()
+
+		if strings.Contains(line, "<div\x20class=\"toggle") &&
+			strings.Contains(line, "\"\x20id=\"go") {
+			parts = strings.Split(line, "\x22")
+
+			if len(parts) >= 3 && parts[3][0:2] == "go" {
+				versions = append(versions, parts[3])
+			}
+		}
+	}
+
+	return versions
+}
+
+func latestVersion() string {
+	var versions []string = availableVersions()
+
+	if len(versions) > 0 {
+		return versions[0]
+	}
+
+	return ""
+}
+
+func latestVersionUrl() string {
+	var versions []string = availableVersions()
+	var tpl string = "https://storage.googleapis.com/golang/%s.%s-%s.tar.gz"
+
+	if len(versions) > 0 {
+		return fmt.Sprintf(tpl, versions[0], runtime.GOOS, runtime.GOARCH)
+	}
+
+	return ""
 }

--- a/src/gobu/remote_test.go
+++ b/src/gobu/remote_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+import "regexp"
+
+func CheckVersionName(t *testing.T, name string) {
+	re := regexp.MustCompile(`^go[0-9]+\.[0-9]+(\.[0-9]+)?$`)
+
+	if !re.MatchString(name) {
+		t.Fatalf("Version name is invalid: %s", name)
+	}
+}
+
+func TestAvailableVersions(t *testing.T) {
+	versions := availableVersions()
+
+	for _, name := range versions {
+		CheckVersionName(t, name)
+	}
+}
+
+func TestLatestVersion(t *testing.T) {
+	CheckVersionName(t, latestVersion())
+}
+
+func TestLatestVersionUrl(t *testing.T) {
+	url := latestVersionUrl()
+	re := regexp.MustCompile(`go[0-9\.]{1,11}.\S+-\S+\.tar\.gz$`)
+
+	if !re.MatchString(url) {
+		t.Fatalf("Latest version URL is invalid: %s", url)
+	}
+}

--- a/src/gobu/remote_test.go
+++ b/src/gobu/remote_test.go
@@ -1,7 +1,18 @@
 package main
 
-import "testing"
-import "regexp"
+import (
+	"bytes"
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+var content = `
+	<div class="toggle" id="go1.2.3">
+	<div class="toggleVisible" id="go1.2.4">
+	<div class="toggle" id="go1.2.5">
+	<div class="toggleVisible" id="go2.0.3">
+	<div class="toggle" id="go3.0">`
 
 func CheckVersionName(t *testing.T, name string) {
 	re := regexp.MustCompile(`^go[0-9]+\.[0-9]+(\.[0-9]+)?$`)
@@ -12,19 +23,33 @@ func CheckVersionName(t *testing.T, name string) {
 }
 
 func TestAvailableVersions(t *testing.T) {
-	versions := availableVersions()
+	stream := bytes.NewBufferString(content)
+	versions := availableVersions(stream)
+	expected := []string{
+		"go1.2.3",
+		"go1.2.4",
+		"go1.2.5",
+		"go2.0.3",
+		"go3.0",
+	}
 
 	for _, name := range versions {
 		CheckVersionName(t, name)
 	}
+
+	if !reflect.DeepEqual(versions, expected) {
+		t.Fatalf("Incorrect extracted versions: %s", versions)
+	}
 }
 
 func TestLatestVersion(t *testing.T) {
-	CheckVersionName(t, latestVersion())
+	stream := bytes.NewBufferString(content)
+	CheckVersionName(t, latestVersion(stream))
 }
 
 func TestLatestVersionUrl(t *testing.T) {
-	url := latestVersionUrl()
+	stream := bytes.NewBufferString(content)
+	url := latestVersionUrl(stream)
 	re := regexp.MustCompile(`go[0-9\.]{1,11}.\S+-\S+\.tar\.gz$`)
 
 	if !re.MatchString(url) {


### PR DESCRIPTION
Option `-available` will send a HTTP GET request to the download page of the official website of the Go project, then it will find all the HTML tags identified by a CSS class name _"toggle"_ or _"toggleVisible"_ for the latest stable version. Then it will process the text and print the list in the console. Note that I am also modifying the content of the Git ignore file to allow the addition of the test files, it seems that the current exclusion rules are targeting everything inside the parent source directory instead of the unnecessary files inside the child source directory located inside `src/gobu/`

**EDIT:** I have added the timeout, by default it will be 5 secs, I was thinking to move that number into an individual variable _(maybe a global)_ or an environment variable so people can override it by hand, but then thought that it was premature to think about that now. Regarding the test cases, I don't have much experience mocking HTTP requests, I decided to separate the code that sends the HTTP request from the code that parses and extracts the relevant data, then adding a new parameter in the all new functions associated with this feature to expect an _io.Reader_ which in the tests is built by hand. Let me know if there is a better way to do this, as of now the execution of the tests will not send real HTTP requests so that is something, but if there is a better way to mock this I am happy to learn.
